### PR TITLE
Glide package should match import path

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/mwitkow/kedge
+package: github.com/improbable-eng/kedge
 import:
 - package: github.com/bshuster-repo/logrus-logstash-hook
 - package: github.com/golang/glog


### PR DESCRIPTION
Small fix for something that was missed in the repo migration.