### PR TITLE
Fixed passing headers through gRPC proxies.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -181,10 +181,9 @@
   revision = "a55ca57f374a8846924b030f534d8b8211508cf0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mwitkow/grpc-proxy"
   packages = ["proxy"]
-  revision = "97396d94749c00db659393ba5123f707062f829f"
+  revision = "67591eb23c48346a480470e462289835d96f70da"
 
 [[projects]]
   name = "github.com/oklog/oklog"
@@ -341,6 +340,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b366f3abaeb2b92c01b5431b3f81d6a2db6b66a7be63cb024e4d45e339841399"
+  inputs-digest = "fd5a33604a4cd343f10bf4135b85545a401ce92687f029d472efda491c5a542a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,6 +62,7 @@
 
 [[constraint]]
   name = "github.com/mwitkow/grpc-proxy"
+  revision = "67591eb23c48346a480470e462289835d96f70da"
 
 [[constraint]]
   name = "github.com/oklog/oklog"

--- a/pkg/grpc/metadata/metadata.go
+++ b/pkg/grpc/metadata/metadata.go
@@ -9,7 +9,7 @@ import (
 func CloneIncomingToOutgoing(ctx context.Context) context.Context {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		md = metadata.Pairs()
+		return ctx
 	}
 	// Copy the inbound metadata explicitly.
 	return metadata.NewOutgoingContext(ctx, md.Copy())

--- a/pkg/grpc/metadata/metadata.go
+++ b/pkg/grpc/metadata/metadata.go
@@ -1,0 +1,16 @@
+package grpc_metadata
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func CloneIncomingToOutgoing(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.Pairs()
+	}
+	// Copy the inbound metadata explicitly.
+	return metadata.NewOutgoingContext(ctx, md.Copy())
+}

--- a/pkg/grpcutils/metadata.go
+++ b/pkg/grpcutils/metadata.go
@@ -1,4 +1,4 @@
-package grpc_metadata
+package grpcutils
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func CloneIncomingToOutgoing(ctx context.Context) context.Context {
+func CloneIncomingToOutgoingMD(ctx context.Context) context.Context {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ctx

--- a/pkg/kedge/grpc/director/director.go
+++ b/pkg/kedge/grpc/director/director.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
-	"github.com/improbable-eng/kedge/pkg/grpc/metadata"
+	"github.com/improbable-eng/kedge/pkg/grpcutils"
 	"github.com/improbable-eng/kedge/pkg/kedge/grpc/backendpool"
 	"github.com/improbable-eng/kedge/pkg/kedge/grpc/director/router"
 	"github.com/mwitkow/grpc-proxy/proxy"
@@ -24,7 +24,7 @@ func New(pool backendpool.Pool, router router.Router) proxy.StreamDirector {
 			return ctx, nil, err
 		}
 
-		ctx = grpc_metadata.CloneIncomingToOutgoing(ctx)
+		ctx = grpcutils.CloneIncomingToOutgoingMD(ctx)
 
 		grpc_ctxtags.Extract(ctx).Set("grpc.proxy.backend", beName)
 		cc, err := pool.Conn(beName)

--- a/pkg/winch/grpc/proxy.go
+++ b/pkg/winch/grpc/proxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
-	"github.com/improbable-eng/kedge/pkg/grpc/metadata"
+	"github.com/improbable-eng/kedge/pkg/grpcutils"
 	"github.com/improbable-eng/kedge/pkg/http/header"
 	"github.com/improbable-eng/kedge/pkg/map"
 	"github.com/improbable-eng/kedge/pkg/tokenauth"
@@ -51,7 +51,7 @@ func New(mapper kedge_map.Mapper, config *tls.Config, debugMode bool) proxy.Stre
 			tags.Set(header.RequestKedgeForceInfoLogs, os.ExpandEnv("winch-$USER"))
 		}
 
-		ctx = grpc_metadata.CloneIncomingToOutgoing(ctx)
+		ctx = grpcutils.CloneIncomingToOutgoingMD(ctx)
 
 		transportCreds := credentials.NewTLS(config)
 		// Make sure authority is ok.


### PR DESCRIPTION
This required to update grpc-proxy to newest changes.

Basically before that change - if you put any header (metadata) in client, it will be not proxied through the hops.

TODO in next PRs: Refactor tests to some table tests

PTAL @stefan-improbable

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>