### PR TITLE
k8sresolver: Fixed critical bug in update detection.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -553,6 +553,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "193c94a358e6f49fc807d16a7bd529491c872ef239fdf72aa38765db9d3dddf9"
+  inputs-digest = "cc4d3e9fd525511c854711dd5d20dd9efe55261361ea6b77ba46cc9345e13951"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -553,6 +553,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cc4d3e9fd525511c854711dd5d20dd9efe55261361ea6b77ba46cc9345e13951"
+  inputs-digest = "193c94a358e6f49fc807d16a7bd529491c872ef239fdf72aa38765db9d3dddf9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/kedge/grpc/backendpool/backend.go
+++ b/pkg/kedge/grpc/backendpool/backend.go
@@ -163,7 +163,8 @@ func chooseNamingResolver(cnf *pb.Backend) (string, naming.Resolver, error) {
 		return srvresolver.NewFromConfig(s)
 	}
 	if k := cnf.GetK8S(); k != nil {
-		return k8sresolver.NewFromConfig(k)
+		rsv, err := k8sresolver.NewFromFlags()
+		return k.GetDnsPortName(), rsv, err
 	}
 	if k := cnf.GetHost(); k != nil {
 		return hostresolver.NewFromConfig(k)

--- a/pkg/kedge/http/backendpool/backend.go
+++ b/pkg/kedge/http/backendpool/backend.go
@@ -192,7 +192,8 @@ func chooseNamingResolver(cnf *pb.Backend) (string, naming.Resolver, error) {
 		return srvresolver.NewFromConfig(s)
 	}
 	if k := cnf.GetK8S(); k != nil {
-		return k8sresolver.NewFromConfig(k)
+		rsv, err := k8sresolver.NewFromFlags()
+		return k.GetDnsPortName(), rsv, err
 	}
 	if k := cnf.GetHost(); k != nil {
 		return hostresolver.NewFromConfig(k)

--- a/pkg/resolvers/k8s/resolver.go
+++ b/pkg/resolvers/k8s/resolver.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/improbable-eng/kedge/pkg/k8s"
-	pb "github.com/improbable-eng/kedge/protogen/kedge/config/common/resolvers"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/naming"
 )
@@ -24,12 +23,12 @@ type resolver struct {
 	cl *client
 }
 
-func NewFromConfig(conf *pb.K8SResolver) (target string, name naming.Resolver, err error) {
+func NewFromFlags() (name naming.Resolver, err error) {
 	apiClient, err := k8s.NewFromFlags()
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
-	return conf.GetDnsPortName(), NewWithClient(apiClient), nil
+	return NewWithClient(apiClient), nil
 }
 
 // NewWithClient returns a new Kubernetes resolver using given k8s.APIClient configured to be used against kube-apiserver.

--- a/pkg/resolvers/k8s/streamer.go
+++ b/pkg/resolvers/k8s/streamer.go
@@ -77,8 +77,8 @@ type eventObject struct {
 	*v1.Endpoints
 }
 
-// proxy receives events in loop and proxies to changeCh. If event include some error, or stream errors it always returns
-// error, because watchers.Next errors are meant to irrecoverable. On graceful EOF, or cancelled context, no error is returned.
+// proxy receives events in loop and proxies to changeCh. If event include some error, or stream errors, it always returns
+// error. This is because watchers.Next errors are meant to irrecoverable. On cancelled context, no error is returned.
 func proxy(ctx context.Context, decoder *json.Decoder, endpCh chan<- change) error {
 	var event event
 

--- a/pkg/resolvers/k8s/streamer_test.go
+++ b/pkg/resolvers/k8s/streamer_test.go
@@ -163,7 +163,7 @@ func TestStreamWatcher_NotSupportedType_EventErr_ClosesConn(t *testing.T) {
 		t.Error("No err was expected")
 	case <-changeCh:
 		t.Error("No event was expected")
-		// Not really nice to use time in tests, but should be enough for now.
+	// Not really nice to use time in tests, but should be enough for now.
 	case <-time.After(200 * time.Millisecond):
 	}
 	require.True(t, connMock.isClosed())
@@ -208,7 +208,7 @@ func TestStreamWatcher_ErrorEventType_EventErr_ClosesConn(t *testing.T) {
 		t.Error("No err was expected")
 	case <-changeCh:
 		t.Error("No event was expected")
-		// Not really nice to use time in tests, but should be enough for now.
+	// Not really nice to use time in tests, but should be enough for now.
 	case <-time.After(200 * time.Millisecond):
 	}
 	require.True(t, connMock.isClosed())
@@ -239,7 +239,7 @@ func TestStreamWatcher_EOF_EventErr_ClosesConn(t *testing.T) {
 		t.Error("No err was expected")
 	case <-changeCh:
 		t.Error("No event was expected")
-		// Not really nice to use time in tests, but should be enough for now.
+	// Not really nice to use time in tests, but should be enough for now.
 	case <-time.After(200 * time.Millisecond):
 	}
 	require.True(t, connMock.isClosed())

--- a/pkg/resolvers/k8s/watcher.go
+++ b/pkg/resolvers/k8s/watcher.go
@@ -2,17 +2,14 @@ package k8sresolver
 
 import (
 	"context"
+	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/naming"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
 )
-
-type watchResult struct {
-	ep  *event
-	err error
-}
 
 // A Watcher provides name resolution updates by watching endpoints API.
 // It works by watching endpoint Watch API (retries if connection broke). Returned events with
@@ -20,28 +17,28 @@ type watchResult struct {
 type watcher struct {
 	ctx    context.Context
 	cancel context.CancelFunc
+	target targetEntry
 
-	target      targetEntry
-	watchChange chan watchResult
-	lastUpdates map[string]struct{}
+	streamer  *streamer
+	endpoints map[key]string
 }
 
 func startNewWatcher(target targetEntry, epClient endpointClient) (*watcher, error) {
 	// NOTE(bplotka): Would love to have proper context from above but naming.Resolver does not allow that.
 	ctx, cancel := context.WithCancel(context.Background())
-	w := &watcher{
-		ctx:         ctx,
-		cancel:      cancel,
-		target:      target,
-		watchChange: make(chan watchResult),
-		lastUpdates: make(map[string]struct{}),
-	}
 
-	err := startWatchingEndpointsChanges(ctx, target, epClient, w.watchChange)
+	s, err := startNewStreamer(ctx, target, epClient)
 	if err != nil {
 		return nil, err
 	}
-	return w, nil
+
+	return &watcher{
+		ctx:       ctx,
+		cancel:    cancel,
+		target:    target,
+		streamer:  s,
+		endpoints: map[key]string{},
+	}, nil
 }
 
 // Close closes the watcher, cleaning up any open connections.
@@ -54,119 +51,136 @@ func (w *watcher) Close() {
 func (w *watcher) Next() ([]*naming.Update, error) {
 	if w.ctx.Err() != nil {
 		// We already stopped.
-		return []*naming.Update(nil), errors.Wrap(w.ctx.Err(), "k8sresolver: watcher.Next already stopped or Next returned error already. "+
+		return []*naming.Update(nil), errors.Wrap(w.ctx.Err(), "watcher.Next already stopped or Next returned error already. "+
 			"Note that watcher errors are not recoverable.")
 	}
 	u, err := w.next()
 	if err != nil {
 		// Just in case.
 		w.Close()
+		return u, errors.Wrap(err, "k8sresolver")
 	}
-	return u, err
+	return u, nil
+}
+
+type key struct {
+	// EndpointAddress fields (usually pod).
+	ns, name string
+}
+
+func keyFromAddr(address v1.EndpointAddress) (key, error) {
+	if address.TargetRef == nil {
+		return key{}, errors.New("address targetRef is empty. Cannot maintain internal state.")
+	}
+	return key{ns: address.TargetRef.Namespace, name: address.TargetRef.Name}, nil
 }
 
 func (w *watcher) next() ([]*naming.Update, error) {
-	updates := make([]*naming.Update, 0)
-	updatedEndpoints := make(map[string]struct{})
-	var event event
+	var (
+		updates           []*naming.Update
+		change            change
+		changeCh, errCh   = w.streamer.ResultChans()
+		endpointsToUpdate = map[key]string{}
+	)
+
 	select {
 	case <-w.ctx.Done():
 		// We already stopped.
 		return []*naming.Update(nil), w.ctx.Err()
-	case r := <-w.watchChange:
-		if r.err != nil {
-			return []*naming.Update(nil), errors.Wrap(r.err, "k8sresolver: error on reading event stream")
-		}
-		event = *r.ep
+	case err := <-errCh:
+		return []*naming.Update(nil), errors.Wrap(err, "error on reading change stream")
+	case change = <-changeCh:
 	}
 
-	// Translate kube api endpoint watch event to resolver address and put into map for easier lookup.
-	for _, subset := range event.Object.Subsets {
-		updatedAddresses, err := subsetToAddresses(w.target, subset)
+	// Translate kube api endpoint watch change to resolver address and put into map for easier lookup.
+	for _, subset := range change.Subsets {
+		var err error
+		endpointsToUpdate, err = subsetToAddresses(w.target, subset)
 		if err != nil {
-			return []*naming.Update(nil), errors.Wrap(err, "k8sresolver: failed to convert k8s endpoint subset to update Addr")
+			return []*naming.Update(nil), errors.Wrap(err, "failed to convert k8s endpoint subset to update Addr")
 		}
 
-		for _, address := range updatedAddresses {
-			updatedEndpoints[address] = struct{}{}
+		if len(endpointsToUpdate) > 0 {
+			// Expected port found.
+			break
 		}
+
+		// Target port not found yet. Maybe other subsets includes target one?
 	}
 
-	// Create updates to add new endpoints.
-	for addr, md := range updatedEndpoints {
-		if _, ok := w.lastUpdates[addr]; ok {
-			continue
-		}
+	switch change.typ {
+	case watch.Added:
+		// Create updates to add new endpoints.
+		for k, addr := range endpointsToUpdate {
+			_, ok := w.endpoints[k]
+			if ok {
+				return []*naming.Update(nil), errors.Errorf("malformed internal state for endpoints. "+
+					"On added event type, we got update for %v that already exists in %v. Doing resync...", k, w.endpoints)
+			}
 
-		updates = append(updates, &naming.Update{Op: naming.Add, Addr: addr, Metadata: md})
-	}
-	// Create updates to delete old endpoints.
-	for addr := range w.lastUpdates {
-		if _, ok := updatedEndpoints[addr]; ok {
-			continue
+			w.endpoints[k] = addr
+			updates = append(updates, &naming.Update{Op: naming.Add, Addr: addr})
 		}
-		updates = append(updates, &naming.Update{Op: naming.Delete, Addr: addr, Metadata: nil})
-	}
+	case watch.Modified:
+		for k, addr := range endpointsToUpdate {
+			oldAddr, ok := w.endpoints[k]
+			if !ok {
+				return []*naming.Update(nil), errors.Errorf("malformed internal state for endpoints. "+
+					"On modified event type, we got update for %v that does not exists in %v. Doing resync...", k, w.endpoints)
+			}
 
-	w.lastUpdates = updatedEndpoints
+			updates = append(updates, &naming.Update{Op: naming.Delete, Addr: oldAddr})
+			w.endpoints[k] = addr
+			updates = append(updates, &naming.Update{Op: naming.Add, Addr: addr})
+		}
+	case watch.Deleted:
+		// Create updates to delete old endpoints.
+		for k, addr := range endpointsToUpdate {
+			_, ok := w.endpoints[k]
+			if !ok {
+				return []*naming.Update(nil), errors.Errorf("malformed internal state for endpoints. "+
+					"On delete event type, we got update for %v that does not exists in %v. Doing resync...", k, w.endpoints)
+			}
+
+			updates = append(updates, &naming.Update{Op: naming.Delete, Addr: addr})
+			delete(w.endpoints, k)
+		}
+	}
 	return updates, nil
 }
 
-type endpoints struct {
-	Kind       string   `json:"kind"`
-	APIVersion string   `json:"apiVersion"`
-	Metadata   metadata `json:"metadata"`
-	// If kins: Endpoints
-	Subsets []subset `json:"subsets"`
-	// If kind: Status
-	Status  string `json:"status"`
-	Message string `json:"message"`
-	Code    int    `json:"code"`
-}
-
-type metadata struct {
-	Name            string `json:"name"`
-	ResourceVersion string `json:"resourceVersion"`
-}
-
-type subset struct {
-	Addresses []address `json:"addresses"`
-	Ports     []port    `json:"ports"`
-}
-
-type address struct {
-	IP string `json:"ip"`
-}
-
-type port struct {
-	Name string `json:"name"`
-	Port int    `json:"port"`
-}
-
-func subsetToAddresses(t targetEntry, sub subset) ([]string, error) {
+func subsetToAddresses(t targetEntry, sub v1.EndpointSubset) (map[key]string, error) {
 	if len(sub.Ports) == 0 {
-		return []string(nil), errors.Errorf("retrieved subset update contains no port")
+		return nil, errors.Errorf("retrieved subset update contains no port")
 	}
-
 	var port string
+
+	// targetEntry that is specified for this watcher controls what port we should use.
 	if t.port == noTargetPort {
 		// Get first one spotted.
-		port = strconv.Itoa(sub.Ports[0].Port)
+		port = fmt.Sprintf("%v", sub.Ports[0].Port)
 	} else if t.port.isNamed {
 		for _, p := range sub.Ports {
 			if p.Name == t.port.value {
-				port = strconv.Itoa(p.Port)
+				port = fmt.Sprintf("%v", p.Port)
 				break
 			}
+		}
+		if port == "" {
+			// Not found.
+			return map[key]string{}, nil
 		}
 	} else {
 		port = t.port.value
 	}
 
-	var updatedAddresses []string
+	addrs := map[key]string{}
 	for _, address := range sub.Addresses {
-		updatedAddresses = append(updatedAddresses, net.JoinHostPort(address.IP, port))
+		k, err := keyFromAddr(address)
+		if err != nil {
+			return nil, err
+		}
+		addrs[k] = net.JoinHostPort(address.IP, port)
 	}
-
-	return updatedAddresses, nil
+	return addrs, nil
 }

--- a/pkg/resolvers/k8s/watcher.go
+++ b/pkg/resolvers/k8s/watcher.go
@@ -111,10 +111,9 @@ func (w *watcher) next() ([]*naming.Update, error) {
 		// Target port not found yet. Maybe other subsets includes target one?
 	}
 
-	switch change.typ {
-	case watch.Added:
-		// Create updates to add new endpoints.
-		for k, addr := range endpointsToUpdate {
+	for k, addr := range endpointsToUpdate {
+		switch change.typ {
+		case watch.Added:
 			_, ok := w.endpoints[k]
 			if ok {
 				return []*naming.Update(nil), errors.Errorf("malformed internal state for endpoints. "+
@@ -123,9 +122,7 @@ func (w *watcher) next() ([]*naming.Update, error) {
 
 			w.endpoints[k] = addr
 			updates = append(updates, &naming.Update{Op: naming.Add, Addr: addr})
-		}
-	case watch.Modified:
-		for k, addr := range endpointsToUpdate {
+		case watch.Modified:
 			oldAddr, ok := w.endpoints[k]
 			if !ok {
 				return []*naming.Update(nil), errors.Errorf("malformed internal state for endpoints. "+
@@ -135,10 +132,7 @@ func (w *watcher) next() ([]*naming.Update, error) {
 			updates = append(updates, &naming.Update{Op: naming.Delete, Addr: oldAddr})
 			w.endpoints[k] = addr
 			updates = append(updates, &naming.Update{Op: naming.Add, Addr: addr})
-		}
-	case watch.Deleted:
-		// Create updates to delete old endpoints.
-		for k, addr := range endpointsToUpdate {
+		case watch.Deleted:
 			_, ok := w.endpoints[k]
 			if !ok {
 				return []*naming.Update(nil), errors.Errorf("malformed internal state for endpoints. "+
@@ -147,9 +141,9 @@ func (w *watcher) next() ([]*naming.Update, error) {
 
 			updates = append(updates, &naming.Update{Op: naming.Delete, Addr: addr})
 			delete(w.endpoints, k)
+		default:
+			return []*naming.Update(nil), errors.Errorf("unexpected change type %v", change.typ)
 		}
-	default:
-		return []*naming.Update(nil), errors.Errorf("unexpected change type %v", change.typ)
 	}
 	return updates, nil
 }

--- a/pkg/resolvers/k8s/watcher_test.go
+++ b/pkg/resolvers/k8s/watcher_test.go
@@ -1,0 +1,351 @@
+package k8sresolver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/naming"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+var (
+	testAddr1 = v1.EndpointSubset{
+		Ports: []v1.EndpointPort{
+			{
+				Port: 8080,
+				Name: "someName",
+			},
+			{
+				Port: 8081,
+				Name: "someName1",
+			},
+			{
+				Port: 8082,
+				Name: "someName2",
+			},
+		},
+		Addresses: []v1.EndpointAddress{
+			{
+				IP: "1.2.3.4",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod1",
+					Namespace: "ns1",
+				},
+			},
+		},
+	}
+	modifiedAddr1 = v1.EndpointSubset{
+		Ports: []v1.EndpointPort{
+			{
+				Port: 8080,
+				Name: "someName",
+			},
+		},
+		Addresses: []v1.EndpointAddress{
+			{
+				IP: "1.2.3.5",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod1",
+					Namespace: "ns1",
+				},
+			},
+		},
+	}
+	multipleAddrSubset = v1.EndpointSubset{
+		Ports: []v1.EndpointPort{
+			{
+				Port: 8080,
+				Name: "someName",
+			},
+		},
+		Addresses: []v1.EndpointAddress{
+			{
+				IP: "1.2.3.3",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod1",
+					Namespace: "ns1",
+				},
+			},
+			{
+				IP: "1.2.4.4",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod2",
+					Namespace: "ns1",
+				},
+			},
+			{
+				IP: "1.2.5.5",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod3",
+					Namespace: "ns1",
+				},
+			},
+		},
+	}
+	someAddrSubset = v1.EndpointSubset{
+		Ports: []v1.EndpointPort{
+			{
+				Port: 8080,
+				Name: "someName",
+			},
+		},
+		Addresses: []v1.EndpointAddress{
+			{
+				IP: "1.2.3.3",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod1",
+					Namespace: "ns1",
+				},
+			},
+			{
+				IP: "1.2.4.4",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod2",
+					Namespace: "ns1",
+				},
+			},
+		},
+	}
+	modifiedLastAddrSubset = v1.EndpointSubset{
+		Ports: []v1.EndpointPort{
+			{
+				Port: 8080,
+				Name: "someName",
+			},
+		},
+		Addresses: []v1.EndpointAddress{
+			{
+				IP: "1.2.5.7",
+				TargetRef: &v1.ObjectReference{
+					Name:      "pod3",
+					Namespace: "ns1",
+				},
+			},
+		},
+	}
+)
+
+func TestWatcher_Next_OK(t *testing.T) {
+	for _, tcase := range []struct {
+		watchedTargetPort targetPort
+		changes           []change
+		err               error
+		expectedUpdates   [][]*naming.Update
+		expectedErrs      []error
+	}{
+		{
+			watchedTargetPort: targetPort{},
+			changes:           []change{newTestChange(watch.Added, testAddr1)},
+			expectedUpdates: [][]*naming.Update{
+				{
+					{
+						Addr: "1.2.3.4:8080",
+						Op:   naming.Add,
+					},
+				},
+			},
+		},
+		{
+			watchedTargetPort: targetPort{isNamed: true, value: "someName2"},
+			changes:           []change{newTestChange(watch.Added, testAddr1)},
+			expectedUpdates: [][]*naming.Update{
+				{
+					{
+						Addr: "1.2.3.4:8082",
+						Op:   naming.Add,
+					},
+				},
+			},
+		},
+		{
+			watchedTargetPort: targetPort{value: "9090"},
+			changes:           []change{newTestChange(watch.Added, testAddr1)},
+			expectedUpdates: [][]*naming.Update{
+				{
+					{
+						Addr: "1.2.3.4:9090",
+						Op:   naming.Add,
+					},
+				},
+			},
+		},
+		{
+			// Non existing port just return no IPs. This makes configuration bit harder to debug, but we cannot assume
+			// port is always in any subset.
+			watchedTargetPort: targetPort{isNamed: true, value: "non-existing-port-name"},
+			changes:           []change{newTestChange(watch.Added, testAddr1)},
+			expectedUpdates:   [][]*naming.Update{nil},
+		},
+		{
+			changes: []change{
+				newTestChange(watch.Added, testAddr1),
+				newTestChange(watch.Modified, modifiedAddr1),
+			},
+			expectedUpdates: [][]*naming.Update{
+				{
+					{
+						Addr: "1.2.3.4:8080",
+						Op:   naming.Add,
+					},
+				},
+				{
+					{
+						Addr: "1.2.3.4:8080",
+						Op:   naming.Delete,
+					},
+					{
+						Addr: "1.2.3.5:8080",
+						Op:   naming.Add,
+					},
+				},
+			},
+		},
+		{
+			changes: []change{
+				newTestChange(watch.Added, multipleAddrSubset),
+				newTestChange(watch.Deleted, someAddrSubset),
+				newTestChange(watch.Modified, modifiedLastAddrSubset),
+				newTestChange(watch.Deleted, modifiedLastAddrSubset),
+			},
+			expectedUpdates: [][]*naming.Update{
+				{
+					{
+						Addr: "1.2.3.3:8080",
+						Op:   naming.Add,
+					},
+					{
+						Addr: "1.2.4.4:8080",
+						Op:   naming.Add,
+					},
+					{
+						Addr: "1.2.5.5:8080",
+						Op:   naming.Add,
+					},
+				},
+				{
+					{
+						Addr: "1.2.3.3:8080",
+						Op:   naming.Delete,
+					},
+					{
+						Addr: "1.2.4.4:8080",
+						Op:   naming.Delete,
+					},
+				},
+				{
+					{
+						Addr: "1.2.5.5:8080",
+						Op:   naming.Delete,
+					},
+					{
+						Addr: "1.2.5.7:8080",
+						Op:   naming.Add,
+					},
+				},
+				{
+					{
+						Addr: "1.2.5.7:8080",
+						Op:   naming.Delete,
+					},
+				},
+			},
+		},
+		{
+			// Test case that did not work previously because of bug.
+			changes: []change{
+				newTestChange(watch.Added, testAddr1),
+				newTestChange(watch.Deleted, testAddr1),
+				newTestChange(watch.Added, testAddr1),
+			},
+			expectedUpdates: [][]*naming.Update{
+				{
+					{
+						Addr: "1.2.3.4:8080",
+						Op:   naming.Add,
+					},
+				},
+				{
+					{
+						Addr: "1.2.3.4:8080",
+						Op:   naming.Delete,
+					},
+				},
+				{
+					{
+						Addr: "1.2.3.4:8080",
+						Op:   naming.Add,
+					},
+				},
+			},
+		},
+		// Malformed state cases. We assume this order of events will never happen:
+		{
+			changes: []change{
+				newTestChange(watch.Deleted, testAddr1),
+			},
+			expectedErrs: []error{errors.New("malformed internal state for endpoints. On delete event type, we got update for {ns1 pod1} that does not exists in map[]. Doing resync...")},
+		},
+		{
+			changes: []change{
+				newTestChange(watch.Modified, testAddr1),
+			},
+			expectedErrs: []error{errors.New("malformed internal state for endpoints. On modified event type, we got update for {ns1 pod1} that does not exists in map[]. Doing resync...")},
+		},
+		{
+			changes: []change{
+				newTestChange(watch.Added, testAddr1),
+				newTestChange(watch.Added, testAddr1),
+			},
+			expectedUpdates: [][]*naming.Update{
+				{
+					{
+						Addr: "1.2.3.4:8080",
+						Op:   naming.Add,
+					},
+				},
+			},
+			expectedErrs: []error{nil, errors.New("malformed internal state for endpoints. On added event type, we got update for {ns1 pod1} that already exists in map[{ns1 pod1}:1.2.3.4:8080]. Doing resync...")},
+		},
+	} {
+		ok := t.Run("", func(t *testing.T) {
+			defer leaktest.CheckTimeout(t, 10*time.Second)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			changeCh := make(chan change, 1)
+			errCh := make(chan error, 1)
+			w := &watcher{
+				ctx:    ctx,
+				cancel: cancel,
+				target: targetEntry{port: tcase.watchedTargetPort},
+				streamer: &streamer{
+					changeCh: changeCh,
+					errCh:    errCh,
+				},
+				endpoints: map[key]string{},
+			}
+			defer w.Close()
+
+			for i, change := range tcase.changes {
+				changeCh <- change
+				u, err := w.next()
+				if len(tcase.expectedErrs) > i && tcase.expectedErrs[i] != nil {
+					require.Error(t, err)
+					require.Equal(t, tcase.expectedErrs[i].Error(), err.Error())
+					continue
+				}
+				require.NoError(t, err)
+				require.Equal(t, tcase.expectedUpdates[i], u, "case %d is wrong", i)
+			}
+		})
+		if !ok {
+			return
+		}
+	}
+}

--- a/tools/resolver/main.go
+++ b/tools/resolver/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/improbable-eng/kedge/pkg/resolvers/k8s"
+	"github.com/improbable-eng/kedge/pkg/sharedflags"
+	"github.com/oklog/run"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/naming"
+)
+
+var (
+	flagLogLevel = sharedflags.Set.String("log_level", "info", "Log level")
+	flagTarget   = sharedflags.Set.String("target", "", "Target entry to resolver and watch for new resolutions")
+)
+
+func main() {
+	if err := sharedflags.Set.Parse(os.Args); err != nil {
+		logrus.WithError(err).Fatal("failed parsing flags")
+	}
+
+	lvl, err := logrus.ParseLevel(*flagLogLevel)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Cannot parse log level: %s", *flagLogLevel)
+	}
+	logrus.SetLevel(lvl)
+	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+
+	resolver, err := k8sresolver.NewFromFlags()
+	if err != nil {
+		logrus.WithError(err).Fatal("Cannot create k8s resolver")
+	}
+
+	watcher, err := resolver.Resolve(*flagTarget)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to resolve %s", *flagTarget)
+	}
+	defer watcher.Close()
+
+	var (
+		g     run.Group
+		state = map[string]struct{}{}
+	)
+
+	{
+		ctx, cancel := context.WithCancel(context.Background())
+		g.Add(func() error {
+			for ctx.Err() == nil {
+				updates, err := watcher.Next()
+				if err != nil {
+					return err
+				}
+
+				var msg string
+				for _, up := range updates {
+					if up.Op == naming.Add {
+						state[up.Addr] = struct{}{}
+					} else {
+						delete(state, up.Addr)
+					}
+					msg += fmt.Sprintf("[op: %v, addr: %s]", up.Op, up.Addr)
+				}
+				fmt.Printf("Got Updates: %s\nOverall state: %v\n", msg, state)
+			}
+
+			return nil
+		}, func(error) {
+			watcher.Close()
+			cancel()
+		})
+	}
+	{
+		cancel := make(chan struct{})
+		g.Add(func() error {
+			return interrupt(cancel)
+		}, func(error) {
+			logrus.Infof("\nReceived an interrupt, stopping services...\n")
+			close(cancel)
+		})
+	}
+
+	logrus.Info("Starting standalone resolver")
+	if err := g.Run(); err != nil {
+		logrus.WithError(err).Fatal("Command finished.")
+	}
+}
+
+func interrupt(cancel <-chan struct{}) error {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case <-c:
+		return nil
+	case <-cancel:
+		return errors.New("canceled")
+	}
+}


### PR DESCRIPTION
- Refactored to use as much as possible k8s types.
- More tests
- Fixed logic for state detection
- cmd Tool

PTAL @stefan-improbable, @artsiukhou

It took time, because was assessing if it's worth to move to cache Informer family.
Moving to it is bit of overeengineering to me and loosing control of multiple things including
error handling, logging and stream handling. So sticked to existing implementationm, but simplified bit.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>