### PR TITLE
tripper: Refactored http tripper resolver usage to match interface.

### DIFF
--- a/pkg/reporter/errtypes/errtypes.go
+++ b/pkg/reporter/errtypes/errtypes.go
@@ -38,4 +38,7 @@ const (
 	// This includes EOF's (kedge server timeout) and context cancellations (winch tripperware timeout), as well as any
 	// other winch internal error.
 	TransportUnknownError Type = "transport-unknown-error"
+
+	// IrrecoverableWatcherError indicates unlikely irrecoverable error from resolver's naming.Watcher.
+	IrrecoverableWatcherError Type = "resolver-watcher-irrecoverable"
 )


### PR DESCRIPTION
This is thanks to reconnect that moved inside k8sresolver.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>