### PR TITLE
winch: Close actual client conn for gRPC.

### DIFF
--- a/pkg/winch/grpc/integration_test.go
+++ b/pkg/winch/grpc/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/improbable-eng/kedge/pkg/map"
 	"github.com/improbable-eng/kedge/pkg/winch"
@@ -108,6 +109,8 @@ type WinchIntegrationSuite struct {
 }
 
 func TestWinchIntegrationSuite(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
+
 	suite.Run(t, &WinchIntegrationSuite{})
 }
 

--- a/pkg/winch/grpc/proxy.go
+++ b/pkg/winch/grpc/proxy.go
@@ -78,6 +78,11 @@ func New(mapper kedge_map.Mapper, config *tls.Config, debugMode bool) proxy.Stre
 			net.JoinHostPort(route.URL.Hostname(), route.URL.Port()),
 			dialOpts...,
 		)
+
+		go func() {
+			<-ctx.Done()
+			conn.Close()
+		}()
 		return ctx, conn, err
 	}
 }


### PR DESCRIPTION
This was missing, but still not sure if we should not invest time to add some connection pooling for kedges. Not sure if dial does that for us, most likely not.


Signed-off-by: Bartek Plotka <bwplotka@gmail.com>