### PR TITLE
Removed srv timeouts for debug endpoints.

### DIFF
--- a/cmd/kedge/main.go
+++ b/cmd/kedge/main.go
@@ -334,8 +334,6 @@ func debugServer(logEntry *log.Entry, middlewares chi.Middlewares, noAuthMiddlew
 	m.Handle("/debug/events", middlewares.HandlerFunc(trace.Events))
 
 	return &http.Server{
-		WriteTimeout: *flagHttpMaxWriteTimeout,
-		ReadTimeout:  *flagHttpMaxReadTimeout,
 		ErrorLog:     http_logrus.AsHttpLogger(logEntry.WithField(ctxtags.TagForScheme, "tls")),
 		Handler:      m,
 	}, nil


### PR DESCRIPTION
This is due to: https://github.com/golang/go/issues/18746

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>