### PR TITLE
Fixed picker reuse request body bug; Ensure all RoundTripper close request body on error cases.

### DIFF
--- a/pkg/http/tripperware/auth.go
+++ b/pkg/http/tripperware/auth.go
@@ -31,7 +31,7 @@ type authTripper struct {
 func (t *authTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	route, ok, err := getRoute(req.Context())
 	if err != nil {
-		_ = Close(req.Body)
+		closeIfNotNil(req.Body)
 		return nil, errors.Wrap(err, "authTripper: Failed to get route from context")
 	}
 	if !ok {
@@ -51,7 +51,7 @@ func (t *authTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	val, err := authSource.Token(req.Context())
 	tags.Set(t.authTimeTag, time.Since(now).String())
 	if err != nil {
-		_ = Close(req.Body)
+		closeIfNotNil(req.Body)
 		return nil, errors.Wrapf(err, "authTripper: Failed to get header value from authSource %s", authSource.Name())
 	}
 

--- a/pkg/http/tripperware/auth.go
+++ b/pkg/http/tripperware/auth.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/improbable-eng/go-httpwares/tags"
+	http_ctxtags "github.com/improbable-eng/go-httpwares/tags"
 	"github.com/improbable-eng/kedge/pkg/http/ctxtags"
-	"github.com/improbable-eng/kedge/pkg/map"
+	kedge_map "github.com/improbable-eng/kedge/pkg/map"
 	"github.com/improbable-eng/kedge/pkg/tokenauth"
 	"github.com/pkg/errors"
 )
@@ -31,6 +31,7 @@ type authTripper struct {
 func (t *authTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	route, ok, err := getRoute(req.Context())
 	if err != nil {
+		_ = Close(req.Body)
 		return nil, errors.Wrap(err, "authTripper: Failed to get route from context")
 	}
 	if !ok {
@@ -50,6 +51,7 @@ func (t *authTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	val, err := authSource.Token(req.Context())
 	tags.Set(t.authTimeTag, time.Since(now).String())
 	if err != nil {
+		_ = Close(req.Body)
 		return nil, errors.Wrapf(err, "authTripper: Failed to get header value from authSource %s", authSource.Name())
 	}
 

--- a/pkg/http/tripperware/debug.go
+++ b/pkg/http/tripperware/debug.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"github.com/improbable-eng/go-httpwares/tags"
+	http_ctxtags "github.com/improbable-eng/go-httpwares/tags"
 	"github.com/improbable-eng/kedge/pkg/http/ctxtags"
 	"github.com/improbable-eng/kedge/pkg/http/header"
 )

--- a/pkg/http/tripperware/map.go
+++ b/pkg/http/tripperware/map.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/improbable-eng/go-httpwares/tags"
+	http_ctxtags "github.com/improbable-eng/go-httpwares/tags"
 	"github.com/improbable-eng/kedge/pkg/http/ctxtags"
-	"github.com/improbable-eng/kedge/pkg/map"
+	kedge_map "github.com/improbable-eng/kedge/pkg/map"
 	"github.com/pkg/errors"
 )
 
@@ -45,6 +45,7 @@ func (t *mappingTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		)
 	}
 	if err != nil {
+		_ = Close(req.Body)
 		return nil, errors.Wrapf(err, "mappingTripper: Failed to map host %s and port %s into route", req.URL.Hostname(), req.URL.Port())
 	}
 

--- a/pkg/http/tripperware/map.go
+++ b/pkg/http/tripperware/map.go
@@ -45,7 +45,7 @@ func (t *mappingTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		)
 	}
 	if err != nil {
-		_ = Close(req.Body)
+		closeIfNotNil(req.Body)
 		return nil, errors.Wrapf(err, "mappingTripper: Failed to map host %s and port %s into route", req.URL.Hostname(), req.URL.Port())
 	}
 

--- a/pkg/http/tripperware/route.go
+++ b/pkg/http/tripperware/route.go
@@ -3,7 +3,7 @@ package tripperware
 import (
 	"net/http"
 
-	"github.com/improbable-eng/go-httpwares/tags"
+	http_ctxtags "github.com/improbable-eng/go-httpwares/tags"
 	"github.com/improbable-eng/kedge/pkg/http/ctxtags"
 	"github.com/pkg/errors"
 )
@@ -19,6 +19,7 @@ type routingTripper struct {
 func (t *routingTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	route, ok, err := getRoute(req.Context())
 	if err != nil {
+		_ = Close(req.Body)
 		return nil, errors.Wrap(err, "routingTripper: Failed to get route from context")
 	}
 	if !ok {

--- a/pkg/http/tripperware/route.go
+++ b/pkg/http/tripperware/route.go
@@ -19,7 +19,7 @@ type routingTripper struct {
 func (t *routingTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	route, ok, err := getRoute(req.Context())
 	if err != nil {
-		_ = Close(req.Body)
+		closeIfNotNil(req.Body)
 		return nil, errors.Wrap(err, "routingTripper: Failed to get route from context")
 	}
 	if !ok {

--- a/pkg/http/tripperware/tripperware.go
+++ b/pkg/http/tripperware/tripperware.go
@@ -2,6 +2,7 @@ package tripperware
 
 import (
 	"crypto/tls"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -33,4 +34,11 @@ func Default(config *tls.Config) http.RoundTripper {
 func DefaultWithTransport(transport *http.Transport, config *tls.Config) http.RoundTripper {
 	transport.TLSClientConfig = config
 	return &defaultTripper{Transport: transport}
+}
+
+func Close(r io.Closer) error {
+	if r != nil {
+		return r.Close()
+	}
+	return nil
 }

--- a/pkg/http/tripperware/tripperware.go
+++ b/pkg/http/tripperware/tripperware.go
@@ -36,9 +36,8 @@ func DefaultWithTransport(transport *http.Transport, config *tls.Config) http.Ro
 	return &defaultTripper{Transport: transport}
 }
 
-func Close(r io.Closer) error {
+func closeIfNotNil(r io.Closer) {
 	if r != nil {
-		return r.Close()
+		_ = r.Close()
 	}
-	return nil
 }

--- a/pkg/http/tripperware/tripperware_test.go
+++ b/pkg/http/tripperware/tripperware_test.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/improbable-eng/kedge/pkg/map"
-	"github.com/improbable-eng/kedge/pkg/tokenauth/sources/direct"
+	kedge_map "github.com/improbable-eng/kedge/pkg/map"
+	directauth "github.com/improbable-eng/kedge/pkg/tokenauth/sources/direct"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/kedge/http/integration_test.go
+++ b/pkg/kedge/http/integration_test.go
@@ -609,7 +609,7 @@ func (s *HttpProxyingIntegrationSuite) TestFailOverReverseProxy_BackendEOF() {
 	resp.Body.Close()
 
 	assert.Equal(s.T(), http.StatusBadGateway, resp.StatusCode, "EOF on backend")
-	assert.True(s.T(), resp.Header.Get(header.ResponseKedgeError) != "", "kedge header should be non empty")
+	assert.NotEmpty(s.T(), resp.Header.Get(header.ResponseKedgeError), "kedge header should be non empty")
 }
 
 func (s *HttpProxyingIntegrationSuite) TestLoadbalancingToSecureBackend() {

--- a/pkg/kedge/http/integration_test.go
+++ b/pkg/kedge/http/integration_test.go
@@ -14,12 +14,12 @@
 package http_integration
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -39,14 +39,14 @@ import (
 	"github.com/improbable-eng/kedge/pkg/http/header"
 	"github.com/improbable-eng/kedge/pkg/kedge/common"
 	"github.com/improbable-eng/kedge/pkg/kedge/http/backendpool"
-	"github.com/improbable-eng/kedge/pkg/kedge/http/client"
+	kedge_http "github.com/improbable-eng/kedge/pkg/kedge/http/client"
 	"github.com/improbable-eng/kedge/pkg/kedge/http/director"
 	"github.com/improbable-eng/kedge/pkg/kedge/http/director/adhoc"
 	"github.com/improbable-eng/kedge/pkg/kedge/http/director/router"
-	"github.com/improbable-eng/kedge/pkg/map"
+	kedge_map "github.com/improbable-eng/kedge/pkg/map"
 	"github.com/improbable-eng/kedge/pkg/reporter"
-	"github.com/improbable-eng/kedge/pkg/resolvers/srv"
-	"github.com/improbable-eng/kedge/protogen/kedge/config/common"
+	srvresolver "github.com/improbable-eng/kedge/pkg/resolvers/srv"
+	kedge_config_common "github.com/improbable-eng/kedge/protogen/kedge/config/common"
 	pb_res "github.com/improbable-eng/kedge/protogen/kedge/config/common/resolvers"
 	pb_be "github.com/improbable-eng/kedge/protogen/kedge/config/http/backends"
 	pb_route "github.com/improbable-eng/kedge/protogen/kedge/config/http/routes"
@@ -254,6 +254,11 @@ func (l *localBackends) targets() (targets []*srv.Target) {
 			DialAddr: l.listeners[i].Addr().String(),
 		})
 	}
+	// Regression test: Make sure failed target is handled without double close error.
+	targets = append(targets, &srv.Target{
+		Ttl:      backendResolutionDuration,
+		DialAddr: "127.23.45.56:9999",
+	})
 	defer l.mu.RUnlock()
 	return targets
 }
@@ -452,7 +457,8 @@ func (s *HttpProxyingIntegrationSuite) assertSuccessfulPingback(req *http.Reques
 }
 
 func testRequest(url string, backendSecret string, proxySecret string) *http.Request {
-	req := &http.Request{Method: "GET", URL: urlMustParse(url)}
+	// Regression test: Do GET request with body to ensure body is not double closed.
+	req := &http.Request{Method: "GET", URL: urlMustParse(url), Body: ioutil.NopCloser(bytes.NewReader([]byte("POSTME")))}
 	req.Header = http.Header{}
 	if backendSecret != "" {
 		req.Header.Set("Authorization", backendSecret)
@@ -603,7 +609,7 @@ func (s *HttpProxyingIntegrationSuite) TestFailOverReverseProxy_BackendEOF() {
 	resp.Body.Close()
 
 	assert.Equal(s.T(), http.StatusBadGateway, resp.StatusCode, "EOF on backend")
-	assert.Equal(s.T(), io.EOF.Error(), resp.Header.Get(header.ResponseKedgeError), "EOF error should be in the header")
+	assert.True(s.T(), resp.Header.Get(header.ResponseKedgeError) != "", "kedge header should be non empty")
 }
 
 func (s *HttpProxyingIntegrationSuite) TestLoadbalancingToSecureBackend() {

--- a/pkg/kedge/http/lbtransport/body.go
+++ b/pkg/kedge/http/lbtransport/body.go
@@ -5,25 +5,25 @@ import (
 	"io"
 )
 
-type lazyBufferedReader struct {
+type replayableReader struct {
 	wrapped io.Reader
 	buf     []byte
 	offset  int
 }
 
-func (*lazyBufferedReader) Close() error {
+func (*replayableReader) Close() error {
 	return nil
 }
 
-// rewind allows lazyBufferedReader to be read again.
-func (b *lazyBufferedReader) rewind() {
+// rewind allows replayableReader to be read again.
+func (b *replayableReader) rewind() {
 	if b == nil {
 		return
 	}
 	b.offset = 0
 }
 
-func (b *lazyBufferedReader) Read(p []byte) (n int, err error) {
+func (b *replayableReader) Read(p []byte) (n int, err error) {
 	if b == nil {
 		return 0, io.EOF
 	}
@@ -33,13 +33,14 @@ func (b *lazyBufferedReader) Read(p []byte) (n int, err error) {
 		b.offset += n
 	}
 
-	var n64 int64
 	if err == nil && n < len(p) {
+		var n64 int64
+
 		// Try to buffer rest (if needed) from wrapped io.Reader.
 		tmp := bytes.NewBuffer(b.buf)
 		n64, err = tmp.ReadFrom(io.LimitReader(b.wrapped, int64(len(p)-n)))
+		b.buf = tmp.Bytes()
 		if n64 > 0 {
-			b.buf = tmp.Bytes()
 			copy(p[n:], b.buf[b.offset:])
 			n += int(n64)
 			b.offset += int(n64)
@@ -47,17 +48,17 @@ func (b *lazyBufferedReader) Read(p []byte) (n int, err error) {
 	}
 
 	// Buffer.ReadFrom masks io.EOF so we assume EOF once n == 0 and no error.
-	if err == nil && n == 0 {
+	if err == nil && n == 0 && len(p) > 0 {
 		return 0, io.EOF
 	}
 	return n, err
 }
 
-// newLazyBufferedReader returns lazyBufferedReader that lazely read from underlying reader if needed.
+// newLazyBufferedReader returns replayableReader that lazely read from underlying reader if needed.
 // In worst case scenario all content from src is buffered, in the the best, nothing.
-func newLazyBufferedReader(src io.Reader) *lazyBufferedReader {
+func newLazyBufferedReader(src io.Reader) *replayableReader {
 	if src == nil {
 		return nil
 	}
-	return &lazyBufferedReader{wrapped: src}
+	return &replayableReader{wrapped: src}
 }

--- a/pkg/kedge/http/lbtransport/body.go
+++ b/pkg/kedge/http/lbtransport/body.go
@@ -27,27 +27,29 @@ func (b *lazyBufferedReader) Read(p []byte) (n int, err error) {
 	if b == nil {
 		return 0, io.EOF
 	}
-	defer func() { b.offset += n }()
 
 	if len(b.buf)-b.offset > 0 {
-		n, err = bytes.NewReader(b.buf).Read(p)
-		if err != nil {
-			return n, err
-		}
-		if n == len(p) {
-			return n, nil
+		n, err = bytes.NewReader(b.buf[b.offset:]).Read(p)
+		b.offset += n
+	}
+
+	var n64 int64
+	if err == nil && n < len(p) {
+		// Try to buffer rest (if needed) from wrapped io.Reader.
+		tmp := bytes.NewBuffer(b.buf)
+		n64, err = tmp.ReadFrom(io.LimitReader(b.wrapped, int64(len(p)-n)))
+		if n64 > 0 {
+			b.buf = tmp.Bytes()
+			copy(p[n:], b.buf[b.offset:])
+			n += int(n64)
+			b.offset += int(n64)
 		}
 	}
 
-	tmp := bytes.NewBuffer(b.buf)
-	n64, err := tmp.ReadFrom(io.LimitReader(b.wrapped, int64(len(p)-n)))
-	defer func() { n += int(n64) }()
-
-	if n64 == 0 {
+	// Buffer.ReadFrom masks io.EOF so we assume EOF once n == 0 and no error.
+	if err == nil && n == 0 {
 		return 0, io.EOF
 	}
-	b.buf = tmp.Bytes()
-	copy(p[n:], b.buf[b.offset+n:])
 	return n, err
 }
 
@@ -57,6 +59,5 @@ func newLazyBufferedReader(src io.Reader) *lazyBufferedReader {
 	if src == nil {
 		return nil
 	}
-
 	return &lazyBufferedReader{wrapped: src}
 }

--- a/pkg/kedge/http/lbtransport/body.go
+++ b/pkg/kedge/http/lbtransport/body.go
@@ -1,0 +1,62 @@
+package lbtransport
+
+import (
+	"bytes"
+	"io"
+)
+
+type lazyBufferedReader struct {
+	wrapped io.Reader
+	buf     []byte
+	offset  int
+}
+
+func (*lazyBufferedReader) Close() error {
+	return nil
+}
+
+// rewind allows lazyBufferedReader to be read again.
+func (b *lazyBufferedReader) rewind() {
+	if b == nil {
+		return
+	}
+	b.offset = 0
+}
+
+func (b *lazyBufferedReader) Read(p []byte) (n int, err error) {
+	if b == nil {
+		return 0, io.EOF
+	}
+	defer func() { b.offset += n }()
+
+	if len(b.buf)-b.offset > 0 {
+		n, err = bytes.NewReader(b.buf).Read(p)
+		if err != nil {
+			return n, err
+		}
+		if n == len(p) {
+			return n, nil
+		}
+	}
+
+	tmp := bytes.NewBuffer(b.buf)
+	n64, err := tmp.ReadFrom(io.LimitReader(b.wrapped, int64(len(p)-n)))
+	defer func() { n += int(n64) }()
+
+	if n64 == 0 {
+		return 0, io.EOF
+	}
+	b.buf = tmp.Bytes()
+	copy(p[n:], b.buf[b.offset+n:])
+	return n, err
+}
+
+// newLazyBufferedReader returns lazyBufferedReader that lazely read from underlying reader if needed.
+// In worst case scenario all content from src is buffered, in the the best, nothing.
+func newLazyBufferedReader(src io.Reader) *lazyBufferedReader {
+	if src == nil {
+		return nil
+	}
+
+	return &lazyBufferedReader{wrapped: src}
+}

--- a/pkg/kedge/http/lbtransport/body.go
+++ b/pkg/kedge/http/lbtransport/body.go
@@ -54,9 +54,11 @@ func (b *replayableReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-// newLazyBufferedReader returns replayableReader that lazely read from underlying reader if needed.
-// In worst case scenario all content from src is buffered, in the the best, nothing.
-func newLazyBufferedReader(src io.Reader) *replayableReader {
+// newReplayableReader returns replayableReader.
+// The content read from the source is buffered in a lazy fashion to keep storage requirements
+// limited to a minimum while still allowing for the reader to be rewinded and previously read
+// content to be replayed.
+func newReplayableReader(src io.Reader) *replayableReader {
 	if src == nil {
 		return nil
 	}

--- a/pkg/kedge/http/lbtransport/body_test.go
+++ b/pkg/kedge/http/lbtransport/body_test.go
@@ -65,6 +65,14 @@ func TestLazyBufferedReader(t *testing.T) {
 			expectedBytes: [][]byte{{1}, {2, 3}, {1, 2, 3, 4}, {5}},
 			expectedErrs:  []error{nil, nil, nil, nil},
 		},
+		{
+			src:                 bytes.NewReader([]byte{1, 2, 3, 4}),
+			sequentialReadBytes: []int{8192, 2, 3},
+			rewindBeforeRead:    []bool{false, true, false},
+
+			expectedBytes: [][]byte{{1, 2, 3, 4}, {1, 2}, {3, 4}},
+			expectedErrs:  []error{nil, nil, nil},
+		},
 	} {
 		if ok := t.Run("", func(t *testing.T) {
 			b := newLazyBufferedReader(tcase.src)
@@ -76,9 +84,9 @@ func TestLazyBufferedReader(t *testing.T) {
 				toRead := make([]byte, read)
 
 				n, err := b.Read(toRead)
-				require.Equal(t, tcase.expectedErrs[i], err, "read %d", i)
-				require.Len(t, tcase.expectedBytes[i], n, "read %d", i)
-				require.Equal(t, tcase.expectedBytes[i], toRead[:len(tcase.expectedBytes[i])], "read %d", i)
+				require.Equal(t, tcase.expectedErrs[i], err, "read %d", i+1)
+				require.Len(t, tcase.expectedBytes[i], n, "read %d", i+1)
+				require.Equal(t, tcase.expectedBytes[i], toRead[:len(tcase.expectedBytes[i])], "read %d", i+1)
 			}
 
 		}); !ok {

--- a/pkg/kedge/http/lbtransport/body_test.go
+++ b/pkg/kedge/http/lbtransport/body_test.go
@@ -1,0 +1,88 @@
+package lbtransport
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyBufferedReader(t *testing.T) {
+	for _, tcase := range []struct {
+		src                 io.Reader
+		sequentialReadBytes []int
+		rewindBeforeRead    []bool
+
+		expectedBytes [][]byte
+		expectedErrs  []error
+	}{
+		{
+			src:                 nil,
+			sequentialReadBytes: []int{10},
+			rewindBeforeRead:    []bool{false},
+
+			expectedBytes: [][]byte{{}},
+			expectedErrs:  []error{io.EOF},
+		},
+		{
+			src:                 nil,
+			sequentialReadBytes: []int{10},
+			rewindBeforeRead:    []bool{true},
+
+			expectedBytes: [][]byte{{}},
+			expectedErrs:  []error{io.EOF},
+		},
+		{
+			src:                 bytes.NewReader([]byte{1, 2, 3, 4}),
+			sequentialReadBytes: []int{1, 8192, 8192},
+			rewindBeforeRead:    []bool{false, false, false},
+
+			expectedBytes: [][]byte{{1}, {2, 3, 4}, {}},
+			expectedErrs:  []error{nil, nil, io.EOF},
+		},
+		{
+			src:                 bytes.NewReader([]byte{1, 2, 3, 4}),
+			sequentialReadBytes: []int{1, 2, 4},
+			rewindBeforeRead:    []bool{false, false, false},
+
+			expectedBytes: [][]byte{{1}, {2, 3}, {4}},
+			expectedErrs:  []error{nil, nil, nil},
+		},
+		{
+			src:                 bytes.NewReader([]byte{1, 2, 3, 4, 5, 6}),
+			sequentialReadBytes: []int{1, 2, 2},
+			rewindBeforeRead:    []bool{false, false, false},
+
+			expectedBytes: [][]byte{{1}, {2, 3}, {4, 5}},
+			expectedErrs:  []error{nil, nil, nil},
+		},
+		{
+			src:                 bytes.NewReader([]byte{1, 2, 3, 4, 5}),
+			sequentialReadBytes: []int{1, 2, 4, 2},
+			rewindBeforeRead:    []bool{false, false, true, false},
+
+			expectedBytes: [][]byte{{1}, {2, 3}, {1, 2, 3, 4}, {5}},
+			expectedErrs:  []error{nil, nil, nil, nil},
+		},
+	} {
+		if ok := t.Run("", func(t *testing.T) {
+			b := newLazyBufferedReader(tcase.src)
+
+			for i, read := range tcase.sequentialReadBytes {
+				if tcase.rewindBeforeRead[i] {
+					b.rewind()
+				}
+				toRead := make([]byte, read)
+
+				n, err := b.Read(toRead)
+				require.Equal(t, tcase.expectedErrs[i], err, "read %d", i)
+				require.Len(t, tcase.expectedBytes[i], n, "read %d", i)
+				require.Equal(t, tcase.expectedBytes[i], toRead[:len(tcase.expectedBytes[i])], "read %d", i)
+			}
+
+		}); !ok {
+			return
+		}
+	}
+}

--- a/pkg/kedge/http/lbtransport/body_test.go
+++ b/pkg/kedge/http/lbtransport/body_test.go
@@ -19,7 +19,7 @@ func TestReplayableReader(t *testing.T) {
 		expectedErrs  []error
 	}{
 		{
-			name: "wrapped nil, read should return EOF",
+			name: "WrappedNil_Read_ShouldReturnEOF",
 			src:                 nil,
 			sequentialReadBytes: []int{10},
 			rewindBeforeRead:    []bool{false},
@@ -28,7 +28,7 @@ func TestReplayableReader(t *testing.T) {
 			expectedErrs:  []error{io.EOF},
 		},
 		{
-			name: "wrapped nil, read should return EOF after rewind",
+			name: "WrappedNil_RewindRead_ShouldReturnEOF",
 			src:                 nil,
 			sequentialReadBytes: []int{10},
 			rewindBeforeRead:    []bool{true},
@@ -37,7 +37,7 @@ func TestReplayableReader(t *testing.T) {
 			expectedErrs:  []error{io.EOF},
 		},
 		{
-			name: "small read and two big reads",
+			name: "SmallBigBigReads_FinishedWithEOF",
 			src:                 bytes.NewReader([]byte{1, 2, 3, 4}),
 			sequentialReadBytes: []int{1, 8192, 8192},
 			rewindBeforeRead:    []bool{false, false, false},
@@ -46,7 +46,7 @@ func TestReplayableReader(t *testing.T) {
 			expectedErrs:  []error{nil, nil, io.EOF},
 		},
 		{
-			name: "small reads only",
+			name: "SmallReads_FinishedWithEOF",
 			src:                 bytes.NewReader([]byte{1, 2, 3, 4}),
 			sequentialReadBytes: []int{1, 2, 4, 1},
 			rewindBeforeRead:    []bool{false, false, false, false},
@@ -55,7 +55,7 @@ func TestReplayableReader(t *testing.T) {
 			expectedErrs:  []error{nil, nil, nil, io.EOF},
 		},
 		{
-			name: "small reads taking exactly all bytes in total",
+			name: "SmallReadsTakingExactBytes",
 			src:                 bytes.NewReader([]byte{1, 2, 3, 4, 5}),
 			sequentialReadBytes: []int{1, 2, 2},
 			rewindBeforeRead:    []bool{false, false, false},
@@ -64,7 +64,7 @@ func TestReplayableReader(t *testing.T) {
 			expectedErrs:  []error{nil, nil, nil},
 		},
 		{
-			name: "2 small reads, rewind and read",
+			name: "SmallReadsRewindSmallRead",
 			src:                 bytes.NewReader([]byte{1, 2, 3, 4, 5}),
 			sequentialReadBytes: []int{1, 2, 4, 2},
 			rewindBeforeRead:    []bool{false, false, true, false},
@@ -73,7 +73,7 @@ func TestReplayableReader(t *testing.T) {
 			expectedErrs:  []error{nil, nil, nil, nil},
 		},
 		{
-			name: "big read, rewind and small reads",
+			name: "BigReadRewindSmallReads",
 			src:                 bytes.NewReader([]byte{1, 2, 3, 4}),
 			sequentialReadBytes: []int{8192, 2, 3},
 			rewindBeforeRead:    []bool{false, true, false},
@@ -82,7 +82,7 @@ func TestReplayableReader(t *testing.T) {
 			expectedErrs:  []error{nil, nil, nil},
 		},
 		{
-			name: "big read, rewind and big read and small",
+			name: "BigReadRewindBigReadSmall_FinishedWithEOF",
 			src:                 bytes.NewReader([]byte{1, 2, 3, 4}),
 			sequentialReadBytes: []int{8192, 8192, 3},
 			rewindBeforeRead:    []bool{false, true, false},
@@ -92,7 +92,7 @@ func TestReplayableReader(t *testing.T) {
 		},
 	} {
 		if ok := t.Run(tcase.name, func(t *testing.T) {
-			b := newLazyBufferedReader(tcase.src)
+			b := newReplayableReader(tcase.src)
 
 			for i, read := range tcase.sequentialReadBytes {
 				if tcase.rewindBeforeRead[i] {

--- a/pkg/kedge/http/lbtransport/policy.go
+++ b/pkg/kedge/http/lbtransport/policy.go
@@ -140,7 +140,7 @@ func (rr *roundRobinPolicyPicker) isTargetLocallyBlacklisted(target *Target) boo
 	return ok
 }
 
-func (rr *roundRobinPolicyPicker) Pick(r *http.Request, currentTargets []*Target) (*Target, error) {
+func (rr *roundRobinPolicyPicker) Pick(_ *http.Request, currentTargets []*Target) (*Target, error) {
 	for range currentTargets {
 		count := uint64(len(currentTargets))
 		id := atomic.AddUint64(&(rr.base.atomicCounter), 1)
@@ -159,7 +159,7 @@ func (rr *roundRobinPolicyPicker) Pick(r *http.Request, currentTargets []*Target
 
 		return currentTargets[targetId], nil
 	}
-	return nil, fmt.Errorf("All targets %v are failing, try later.", currentTargets)
+	return nil, fmt.Errorf("all targets %v are failing, try later.", currentTargets)
 }
 
 func (rr *roundRobinPolicyPicker) ExcludeTarget(target *Target) {

--- a/pkg/kedge/http/lbtransport/transport.go
+++ b/pkg/kedge/http/lbtransport/transport.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/improbable-eng/go-httpwares/tags"
+	"github.com/improbable-eng/kedge/pkg/http/tripperware"
+
+	http_ctxtags "github.com/improbable-eng/go-httpwares/tags"
 	"github.com/improbable-eng/kedge/pkg/http/ctxtags"
 	"github.com/improbable-eng/kedge/pkg/reporter"
 	"github.com/improbable-eng/kedge/pkg/reporter/errtypes"
@@ -111,13 +113,23 @@ func (s *tripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if irrecoverableErr != nil {
 		err := errors.Wrapf(irrecoverableErr, "lb: critical naming.Watcher error for target %s. Tripper is closed.", s.targetName)
 		reporter.Extract(r).ReportError(errtypes.IrrecoverableWatcherError, err)
+		_ = tripperware.Close(r.Body)
 		return nil, err
 	}
 
 	if len(targetsRef) == 0 {
 		err := errors.Errorf("lb: no backend is available for %s. 0 resolved addresses.", s.targetName)
 		reporter.Extract(r).ReportError(errtypes.NoResolutionAvailable, err)
+		_ = tripperware.Close(r.Body)
 		return nil, err
+	}
+
+	if r.Body != nil {
+		// We have to own true body for the request because we cannot reuse same reader closer
+		// in multiple calls to http.Transport.
+		body := r.Body
+		defer func() { _ = tripperware.Close(body) }()
+		r.Body = newLazyBufferedReader(body)
 	}
 
 	picker := s.policy.Picker()
@@ -135,6 +147,11 @@ func (s *tripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		// See http.connectMethodKey.
 		r.URL.Host = target.DialAddr
 		tags.Set(ctxtags.TagForTargetAddress, target.DialAddr)
+
+		if r.Body != nil {
+			r.Body.(*lazyBufferedReader).rewind()
+		}
+
 		resp, err := s.parent.RoundTrip(r)
 		if err == nil {
 			return resp, nil

--- a/pkg/kedge/http/lbtransport/transport_test.go
+++ b/pkg/kedge/http/lbtransport/transport_test.go
@@ -1,6 +1,7 @@
 package lbtransport
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -171,12 +172,13 @@ func (s *BalancedRRTransportSuite) callLBTransportAndAssert(requestsPerBackend i
 	for i := 0; i < requestsPerBackend*backendsCount; i++ {
 		wg.Add(1)
 		go func(id int) {
-			resp, err := client.Get("http://my-magic-srv/something")
+			resp, err := client.Post("http://my-magic-srv/something", "spaghetti", bytes.NewReader([]byte("SOMETHING")))
 			if err != nil {
+				fmt.Println(err)
 				s.T().Errorf("Encountered error on request %v: %v", id, err)
 			}
 			_, _ = ioutil.ReadAll(resp.Body)
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			wg.Done()
 		}(i)
 	}


### PR DESCRIPTION
cc @ianbillett

Without this *every* HTTP requests with some kind of Body will fail if first target choosen within backends is unhealthy. 

The reason is that RoundTrip interface states clearly that no req.Body should be returned non-closed from any RoundTrip. However `lbtransport` retries same request that returns (in certain case) from `http.Transport`, so if it has `Body` and it goes to second `http.Transport.RoundTrip` invoke it returns error `error handler double close` or `http: invalid Read on closed Body`

I used TDD logic to fix it: 

I changed `integration_test.go` to reproduce the issue by:
* adding broken target to all backends
* adding non nil Body to request

This exactly reproduced issue seen on production.

The fix:
in `lbtransport` if body is non nil wraps it with `lazyBufferedReader`. It masks close so responsibility of Body close is on `lbtransport` AND every Read is buffered. To make sure the buffer is not kept if not uncecessary we do it in lazy way. Obviously reader is rewinded before each invoke of RT to ensure same view. 

Worth to note that current http.Transport implementation does not really need rewind as no body is read before dial. However we should not assume that it will never change IMO. 

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>
