### PR TITLE
Add back named ports support

### DIFF
--- a/pkg/resolvers/k8s/resolver_test.go
+++ b/pkg/resolvers/k8s/resolver_test.go
@@ -24,6 +24,10 @@ func TestParseTarget(t *testing.T) {
 			expectedErr: errors.Errorf("Bad targetEntry name. It cannot contain any schema. Expected format: %s", ExpectedTargetFmt),
 		},
 		{
+			target:      "service1.ns1:123:123",
+			expectedErr: errors.Errorf("bad targetEntry - it contains multiple \":\" - expected format is %s", ExpectedTargetFmt),
+		},
+		{
 			target: "service1",
 			expectgedTarget: targetEntry{
 				service:   "service1",
@@ -63,7 +67,19 @@ func TestParseTarget(t *testing.T) {
 				service:   "service4",
 				namespace: "ns4",
 				port: targetPort{
-					value: "1010",
+					value:   "1010",
+					isNamed: false,
+				},
+			},
+		},
+		{
+			target: "service5.ns5:some-port",
+			expectgedTarget: targetEntry{
+				service:   "service5",
+				namespace: "ns5",
+				port: targetPort{
+					value:   "some-port",
+					isNamed: true,
 				},
 			},
 		},


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

* Adds back named ports which were removed in https://github.com/improbable-eng/kedge/commit/772f9b2d2092a0ada972096945bee8cd49513da6. We should still support this functionality even though `url.Parse` does not support non-numeric ports since Go 1.12. The k8s resolver in kedge does support named ports.
* Adds back the tests for named ports.
* Add a new test to verify only a single `:` is allowed. 

## Verification

Unit tests. Also run a docker image build from this branch in a testing k8s cluster and dynamic discovery with named ports works.
